### PR TITLE
fix the hardcoded v8 and fix the histogram problem in x resolution

### DIFF
--- a/kolmov/crossval_fit_table.py
+++ b/kolmov/crossval_fit_table.py
@@ -141,7 +141,9 @@ class crossval_fit_table(Logger):
                     # prepare all histograms
                     xmin = int(np.percentile(output , xmin_percentage))
                     xmax = int(np.percentile(output , xmax_percentage))
-
+                    if xmin == xmax:
+                        print('xmin == xmax -> \n make xmin = xmax -1 ')
+                        xmin = xmax - 1
                     xbins = int((xmax-xmin)/xbin_size)
                     ybins = int((ymax-ymin)/ybin_size)
 

--- a/kolmov/crossval_table.py
+++ b/kolmov/crossval_table.py
@@ -715,7 +715,7 @@ class crossval_table( Logger ):
 
                     if test_table is not None:
                         keys = [ key for key in test_table.columns.values if 'passed' in key or 'total' in key]
-                        current_test_table = test_table.loc[test_table.train_tag=='v8'].agg(dict(zip( keys, ['sum']*len(keys))))
+                        current_test_table = test_table.loc[test_table.train_tag==tag].agg(dict(zip( keys, ['sum']*len(keys))))
                         test_pd = (current_test_table['pd_test_passed']/current_test_table['pd_test_total'])*100
                         test_fa = (current_test_table['fa_test_passed']/current_test_table['fa_test_total'])*100
 


### PR DESCRIPTION
I've fixed the problem in the beamer table which always put v8 as a tag; 

In pile-up correction the is a possibility of having almost 0 bins, so I've fixed using a minimum bin;